### PR TITLE
feat(schema): implement node interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",
     "graphql": "^0.9.1",
+    "graphql-relay": "^0.5.1",
     "helmet": "^2.1.2",
     "json-loader": "^0.5.4",
     "jsonwebtoken": "^7.3.0",

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,3 +1,7 @@
+import mongoose from 'mongoose';
+
 export default function loadModels() {
   require('./user.model');
 }
+
+export const getModels = () => mongoose.modelNames().map(name => mongoose.model(name));

--- a/src/server/init/relay-node.js
+++ b/src/server/init/relay-node.js
@@ -1,0 +1,22 @@
+import R from 'ramda';
+import {
+  fromGlobalId,
+  nodeDefinitions,
+} from 'graphql-relay';
+import {getModels} from '../db/models/index';
+import schema from '../schema/schema';
+
+const models = getModels();
+
+export const {nodeInterface, nodeField} = nodeDefinitions(
+  (globalId) => R.pipe(
+    () => fromGlobalId(globalId),
+    localId => models.find(m => m.modelName === localId.type).findById(localId.id)
+  )(globalId),
+
+  // Matches DB models to GraphQL types by name
+  (obj) => R.pipe(
+    () => models.find(m => obj instanceof m),
+    m => schema.getTypeMap()[m.modelName]
+  )(obj)
+);

--- a/src/server/init/relay-node.js
+++ b/src/server/init/relay-node.js
@@ -3,20 +3,25 @@ import {
   fromGlobalId,
   nodeDefinitions,
 } from 'graphql-relay';
+import {logThrowError} from '../../utils/helpers';
+import {then, catchErr} from '../../utils/invokers';
+import {promisify} from '../../utils/monads';
 import {getModels} from '../db/models/index';
 import schema from '../schema/schema';
 
 const models = getModels();
 
 export const {nodeInterface, nodeField} = nodeDefinitions(
-  (globalId) => R.pipe(
-    () => fromGlobalId(globalId),
-    localId => models.find(m => m.modelName === localId.type).findById(localId.id)
-  )(globalId),
+  R.pipe(
+    fromGlobalId,
+    promisify(localId => models.find(m => m.modelName === localId.type).findById(localId.id)),
+    catchErr(logThrowError('Model not found by type name'))
+  ),
 
   // Matches DB models to GraphQL types by name
-  (obj) => R.pipe(
-    () => models.find(m => obj instanceof m),
-    m => schema.getTypeMap()[m.modelName]
-  )(obj)
+  R.pipe(
+    promisify(obj => models.find(m => obj instanceof m)),
+    then(m => schema.getTypeMap()[m.modelName]),
+    catchErr(logThrowError('Model not found by instance'))
+  )
 );

--- a/src/server/schema/object-types/user-type.js
+++ b/src/server/schema/object-types/user-type.js
@@ -2,17 +2,23 @@ import {
   GraphQLString,
   GraphQLNonNull,
   GraphQLObjectType,
-  GraphQLID,
 } from 'graphql';
+import {
+  globalIdField,
+} from 'graphql-relay';
+import {
+  nodeInterface,
+} from '../../init/relay-node';
 
 const userType = new GraphQLObjectType({
   name: 'User',
   fields: {
-    id: {type: new GraphQLNonNull(GraphQLID)},
+    id: globalIdField('User'),
     email: {type: new GraphQLNonNull(GraphQLString)},
     name: {type: GraphQLString},
     imageUrl: {type: GraphQLString},
   },
+  interfaces: [nodeInterface]
 });
 
 export default userType;

--- a/src/server/schema/query/index.js
+++ b/src/server/schema/query/index.js
@@ -3,11 +3,13 @@ import {
 } from 'graphql';
 import viewerType from '../object-types/viewer-type';
 import {verifyUser} from '../../db/controllers/users.controller';
+import {nodeField} from '../../init/relay-node';
 
 const query = new GraphQLObjectType({
   name: 'Query',
   fields: {
-    Viewer: {
+    node: nodeField,
+    viewer: {
       type: viewerType,
       resolve: verifyUser,
     },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,6 @@
+import R from 'ramda';
+
+export const logThrowError = R.curry((msg, err) => { // eslint-disable-line import/prefer-default-export
+  console.error(msg + ':', err);
+  throw new Error(msg);
+});


### PR DESCRIPTION
This is one of the requirements for Relay. `relay-node.js` is implemented in way that allows easier addition of new DB models and GraphQL types without extra edits in the mapping between them because it's created automatically based on DB model and GraphQL type name match.

Closes #18